### PR TITLE
开关服消息

### DIFF
--- a/ChatBridge_client.py
+++ b/ChatBridge_client.py
@@ -260,6 +260,18 @@ def on_death_message(server, message):
 	global client
 	client.sendMessage(message)
 
+
+def on_server_startup(server):
+	setMinecraftServerAndStart(server)
+	global client
+	client.sendMessage('server ' + client.info.name + ' has started up')
+
+
+def on_server_stop(server, return_code):
+	setMinecraftServerAndStart(server)
+	global client
+	client.sendMessage('server ' + client.info.name  + ' stopped')
+
 #  -------------------------------
 # | MCDReforged Compatibility End|
 # -------------------------------


### PR DESCRIPTION
在服务器开启或关闭的发送消息。

镜像服的珍珠炮在调试的时候没有放珍珠，然后发生了一些意外。
镜像服回档时只能在其他服等着，启动完成后也许并不能第一时间知道镜像服已经启动完成。
于是便在ChatBridge_client.py中加了一些对于开关服的响应。