### PR TITLE
当所有客户端都已链接的时候拒绝新链接

### DIFF
--- a/chatbridge/core/server.py
+++ b/chatbridge/core/server.py
@@ -104,6 +104,16 @@ class ChatBridgeServer(ChatBridgeBase):
 			while self.is_running():
 				try:
 					conn, addr = self.__sock.accept()
+
+					all_online = True
+					for c in self.clients.values():
+						if not c.is_online():
+							all_online = False
+							break
+					if all_online:
+						conn.close()
+						continue
+
 					if not self.is_running():
 						conn.close()
 						break


### PR DESCRIPTION
平时在运行的时候碰到很多用半链接扫来扫去的，原来的处理方式会创建很多线程等待数据直到超时，开的时间长了就会占用很多资源。
修改后，在每次有新链接的时候先检测是否有客户端未链接，如果没有的话立刻切断，就避免了佷多浪费。