### PR TITLE
修复 MCDR 更新至 2.8.0 后出错 #36

### DIFF
--- a/chatbridge/impl/utils.py
+++ b/chatbridge/impl/utils.py
@@ -20,7 +20,7 @@ def load_config(config_path: str, config_class: Type[T]) -> T:
 		raise FileNotFoundError(config_path)
 	else:
 		with open(config_path, encoding='utf8') as file:
-			config.update_from(json.load(file))
+			config = config_class.deserialize(json.load(file))
 		with open(config_path, 'w', encoding='utf8') as file:
 			json.dump(config.serialize(), file, ensure_ascii=False, indent=4)
 		return config


### PR DESCRIPTION
修复 MCDR 更新至 2.8.0 以后，Serializable 类删除了 update_from 方法的问题。

经过测试，在 2.8.0 之前与之后的版本中均可运行。